### PR TITLE
LocalRepository makes sure that upload directory is present.

### DIFF
--- a/files/src/main/java/org/matsim/viz/files/file/LocalRepository.java
+++ b/files/src/main/java/org/matsim/viz/files/file/LocalRepository.java
@@ -64,6 +64,7 @@ public class LocalRepository implements Repository {
         Path file = uploadDirectory.resolve(diskFileName);
         FileEntry entry = new FileEntry();
         try {
+            Files.createDirectories(uploadDirectory);
             long bytes = Files.copy(upload.getFile(), file);
             entry.setSizeInBytes(bytes);
         } catch (IOException e) {


### PR DESCRIPTION
Sometimes, ElasticBeanstalk seems to delete folders previously created by the application, which makes this necessary